### PR TITLE
Don't match bitbucket UI elements using hardcoded strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,14 @@ Tested on Firefox 78 - Other browsers _should_ work too, otherwise raise an issu
 | 6.7.5 | 0.3.2 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | 6.8.4 | 0.3.2 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | 6.9.3 | 0.3.2 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |  
-| 6.10.5 | 0.3.2 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| 6.10.5 | 0.3.3 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | 7.0.5 | 0.3.2 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | 7.1.4 | 0.3.2 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | 7.2.5 | 0.3.2 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | 7.3.1 | 0.3.2 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | 7.4.0 | 0.3.2 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | 7.5.0 | 0.3.2 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| 7.6.0 | 0.3.3 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 
 This plugin may work on other versions of Bitbucket Server. Bitbucket version 6 & 7 are supported, it has not been tested on Bitbucket 5.
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.cyanoth</groupId>
     <artifactId>prgroup</artifactId>
-    <version>0.3.2</version>
+    <version>0.3.3</version>
     <packaging>atlassian-plugin</packaging>
 
     <name>Pull Request Reviewer Groups</name>
@@ -21,7 +21,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <amps.version>8.1.0</amps.version>
-        <bitbucket.version>7.4.0</bitbucket.version>
+        <bitbucket.version>7.6.0</bitbucket.version>
         <bitbucket.data.version>${bitbucket.version}</bitbucket.data.version>
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
 


### PR DESCRIPTION
This is a fix for: https://github.com/Cyanoth/Bitbucket-PullRequest-ReviewerGroups/issues/1

Before this change, to decided whether or not to add a button to the page a dom query tries to match text on the page (like "create pull request" or "edit pull request"); However, this won't work for users who have a different language other than English selected in their profile.

This change uses more reliable selectors - that aren't based of strings. 