### PR TITLE
Change Element Selector for Edit PR Dialog Bitbucket 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ Tested on Firefox 78 - Other browsers _should_ work too, otherwise raise an issu
 | 7.3.1 | 0.3.2 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | 7.4.0 | 0.3.2 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | 7.5.0 | 0.3.2 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| 7.6.0 | 0.3.3 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| 7.6.0 | 0.3.5 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| 7.17.5 | 0.3.5 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| 7.21.1 | 0.3.5 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 
 This plugin may work on other versions of Bitbucket Server. Bitbucket version 6 & 7 are supported, it has not been tested on Bitbucket 5.
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.cyanoth</groupId>
     <artifactId>prgroup</artifactId>
-    <version>0.3.3</version>
+    <version>0.3.5</version>
     <packaging>atlassian-plugin</packaging>
 
     <name>Pull Request Reviewer Groups</name>
@@ -21,7 +21,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <amps.version>8.1.0</amps.version>
-        <bitbucket.version>7.6.0</bitbucket.version>
+        <bitbucket.version>7.21.1</bitbucket.version>
         <bitbucket.data.version>${bitbucket.version}</bitbucket.data.version>
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
 

--- a/src/main/resources/js/prgroup.js
+++ b/src/main/resources/js/prgroup.js
@@ -93,7 +93,7 @@ define('PrGroup', [
                         if (bitbucket_version === "7") {
                             let reviewerSelector = $(".user-multi-select")[0] // can't use $("#reviewers-uidXX") ! Where XX is a seemingly a random number with no obvious pattern.
                             if (typeof reviewerSelector !== "undefined") {
-                                $("#" + reviewerSelector.id.concat("-helper")).before(add_group_button_element);
+                                $("#" + reviewerSelector.id).after(add_group_button_element);
                                 addHandlers();
                             }
                         }


### PR DESCRIPTION
The element '-helper' no longer exists needed as found in #4 - Bitbucket v7.17.5+; But we don't actually need it, we can just use the selector-box element to append the button.

Tested on Bitbucket v7.6.0, v7.17.5, v7.21.1 (latest LTS)